### PR TITLE
Updates syntax for Elixir 1.4.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule PhoenixExpug.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      package: package(),
-     deps: deps()
+     deps: deps()]
   end
 
   def application do

--- a/mix.exs
+++ b/mix.exs
@@ -7,8 +7,8 @@ defmodule PhoenixExpug.Mixfile do
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     package: package,
-     deps: deps]
+     package: package(),
+     deps: deps()
   end
 
   def application do


### PR DESCRIPTION
I'm using Elixir 1.4.0 in a project and I'm getting these warning messages. This PR should fix it.

Here is a sample output of the warning message.
```
warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  <project_dir>/deps/phoenix_expug/mix.exs:10

warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
 <project_dir>/deps/phoenix_expug/mix.exs:11
```